### PR TITLE
Refactor internals and align documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "arcgeocoder" in publications use:'
 type: software
 license: MIT
 title: 'arcgeocoder: Geocode with the ''ArcGIS'' REST API Service'
-version: 0.4.0
+version: 0.4.0.9000
 doi: 10.32614/CRAN.package.arcgeocoder
 identifiers:
 - type: doi
@@ -32,7 +32,7 @@ preferred-citation:
     orcid: https://orcid.org/0000-0001-8457-4658
   doi: 10.32614/CRAN.package.arcgeocoder
   year: '2026'
-  version: 0.4.0
+  version: 0.4.0.9000
   url: https://dieghernan.github.io/arcgeocoder/
   abstract: Lightweight interface for geocoding addresses and reverse geocoding locations
     around the world with the ArcGIS REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ doi: 10.32614/CRAN.package.arcgeocoder
 identifiers:
 - type: doi
   value: 10.32614/CRAN.package.arcgeocoder
-abstract: Lightweight interface for geocoding addresses and reverse geocoding locations
+abstract: Lightweight interface for geocoding addresses and reverse geocoding coordinates
   around the world with the 'ArcGIS' REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>.
   Address text can be converted to location candidates and coordinates can be converted
   into addresses. No API key is required.
@@ -34,7 +34,7 @@ preferred-citation:
   year: '2026'
   version: 0.4.0.9000
   url: https://dieghernan.github.io/arcgeocoder/
-  abstract: Lightweight interface for geocoding addresses and reverse geocoding locations
+  abstract: Lightweight interface for geocoding addresses and reverse geocoding coordinates
     around the world with the ArcGIS REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>.
     Address text can be converted to location candidates and coordinates can be converted
     into addresses. No API key is required.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arcgeocoder
 Title: Geocode with the 'ArcGIS' REST API Service
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R:
     person("Diego", "Hernangómez", , "diego.hernangomezherrero@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8457-4658"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R:
     person("Diego", "Hernangómez", , "diego.hernangomezherrero@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8457-4658"))
 Description: Lightweight interface for geocoding addresses and reverse
-    geocoding locations around the world with the 'ArcGIS' REST API
+    geocoding coordinates around the world with the 'ArcGIS' REST API
     service
     <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>.
     Address text can be converted to location candidates and coordinates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # arcgeocoder (development version)
 
+- Reviewed and aligned documentation terminology across **roxygen2**, README and
+  vignettes with AI assistance.
+- Refactored internal geocoding helpers for simpler maintenance, including
+  shared query, progress, validation and API-call utilities. The refactor was
+  developed with AI assistance and does not change the public API.
+
 # arcgeocoder 0.4.0
 
 - Migrated the documentation to Quarto (#24).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# arcgeocoder (development version)
+
 # arcgeocoder 0.4.0
 
 - Migrated the documentation to Quarto (#24).

--- a/R/arc_geo.R
+++ b/R/arc_geo.R
@@ -1,11 +1,11 @@
 #' Geocode addresses with the ArcGIS REST API
 #'
 #' @description
-#' Geocodes addresses given as character values and returns the
+#' Geocodes addresses supplied as character values and returns the
 #' [tibble][tibble::tbl_df] associated with each query.
 #'
 #' This function uses the `SingleLine` approach detailed in the
-#' [ArcGIS REST docs](`r arcurl("cand")`). For multi-field queries (i.e.
+#' [ArcGIS REST docs](`r arcurl("cand")`). For multi-field queries (that is,
 #' using specific address components), use [arc_geo_multi()].
 #'
 #' @param address Single-line address text (e.g.
@@ -27,19 +27,22 @@
 #'
 #' @inheritParams arc_reverse_geo
 #'
-#' @references
-#' [ArcGIS REST `findAddressCandidates`](`r arcurl("cand")`).
-#'
-#' @return
-#'
-#' ```{r child = "man/chunks/out1.Rmd"}
-#' ```
-#'
 #' @details
 #' See the [ArcGIS REST docs](`r arcurl("cand")`) for more information and
 #' valid values.
 #'
 #' @inheritSection arc_reverse_geo `outsr`
+#'
+#' @return
+#' ```{r child = "man/chunks/out1.Rmd"}
+#' ```
+#'
+#' @references
+#' [ArcGIS REST `findAddressCandidates`](`r arcurl("cand")`).
+#'
+#' @family geocoding
+#'
+#' @seealso [tidygeocoder::geo()]
 #'
 #' @examplesIf arcgeocoder_check_access()
 #' \donttest{
@@ -66,10 +69,6 @@
 #' }
 #' @export
 #' @encoding UTF-8
-#'
-#' @seealso [tidygeocoder::geo()]
-#' @family geocoding
-#'
 arc_geo <- function(
   address,
   lat = "lat",
@@ -85,64 +84,35 @@ arc_geo <- function(
   category = NULL,
   custom_query = list()
 ) {
-  if (limit > 50) {
-    message(paste(
-      "\nThe ArcGIS REST API provides a maximum of 50 results.",
-      "Your query may be incomplete."
-    ))
-    limit <- min(50, limit)
-  }
+  limit <- restrict_arc_limit(limit)
 
   # Deduplicate addresses before querying.
   init_key <- dplyr::tibble(query = address)
   key <- unique(address)
 
-  # Set progress bar.
-  ntot <- length(key)
-  # Show progress bar only for multiple addresses.
-  progressbar <- all(progressbar, ntot > 1)
-  if (progressbar) {
-    pb <- txtProgressBar(min = 0, max = ntot, width = 50, style = 3)
-  }
-  seql <- seq(1, ntot, 1)
-
   # Add API arguments to the custom query.
-  if (isTRUE(full_results)) {
-    # Override any `outFields` parameter provided in `custom_query`.
-    custom_query$outFields <- "*"
-  }
+  custom_query <- add_find_address_params(
+    custom_query,
+    full_results = full_results,
+    sourcecountry = sourcecountry,
+    outsr = outsr,
+    langcode = langcode,
+    category = category
+  )
 
-  custom_query$sourceCountry <- sourcecountry
-  custom_query$outSR <- outsr
-  custom_query$langCode <- langcode
-  custom_query$category <- category
-
-  all_res <- lapply(seql, function(x) {
-    ad <- key[x]
-    if (progressbar) {
-      setTxtProgressBar(pb, x)
-    }
-    arc_geo_single(
-      address = ad,
-      lat,
-      long,
-      limit,
-      full_results,
-      return_addresses,
-      verbose,
-      custom_query,
-      singleline = TRUE
-    )
-  })
-  if (progressbar) {
-    close(pb)
-  }
-
-  all_res <- dplyr::bind_rows(all_res)
-  all_res <- dplyr::left_join(init_key, all_res, by = "query")
-
-  all_res[all_res == ""] <- NA
-  all_res
+  arc_geo_bulk(
+    key = key,
+    init_key = init_key,
+    lat = lat,
+    long = long,
+    limit = limit,
+    full_results = full_results,
+    return_addresses = return_addresses,
+    verbose = verbose,
+    custom_query = custom_query,
+    singleline = TRUE,
+    progressbar = progressbar
+  )
 }
 
 arc_geo_single <- function(
@@ -157,10 +127,7 @@ arc_geo_single <- function(
   singleline = TRUE
 ) {
   # Step 1: Download ----
-  api <- paste0(
-    "https://geocode.arcgis.com/arcgis/rest/",
-    "services/World/GeocodeServer/findAddressCandidates?"
-  )
+  api <- arc_endpoint_url("findAddressCandidates")
 
   # Compose URL.
   if (singleline) {

--- a/R/arc_geo_categories.R
+++ b/R/arc_geo_categories.R
@@ -18,8 +18,8 @@
 #'   Several values can also be supplied as a vector (for example,
 #'   `c("Cinema", "Museum")`), which performs one call for each value. See
 #'   **Details**.
-#' @param limit Maximum number of results per query. ArcGIS API limits a single
-#'   request to 50 results.
+#' @param limit Maximum number of results per query. The ArcGIS REST API limits
+#'   a single request to 50 results.
 #' @inheritParams arc_geo
 #' @inheritParams arc_reverse_geo
 #' @inheritDotParams arc_geo -address -return_addresses -progressbar
@@ -45,20 +45,17 @@
 #'
 #' @inheritSection arc_reverse_geo `outsr`
 #'
+#' @return
+#' ```{r child = "man/chunks/out1.Rmd"}
+#' ```
+#'
+#' @family geocoding
+#'
 #' @seealso
 #' [ArcGIS REST Category filtering](`r arcurl("filt")`).
 #'
 #' [arc_categories]
 #'
-#' @family geocoding
-#'
-#' @return
-#'
-#' ```{r child = "man/chunks/out1.Rmd"}
-#' ```
-#'
-#' @export
-#' @encoding UTF-8
 #' @examplesIf arcgeocoder_check_access()
 #' \donttest{
 #' # Full workflow: gas stations near Carabanchel, Madrid.
@@ -132,6 +129,8 @@
 #'     subtitle = "Search near with name and bounding box"
 #'   )
 #' }
+#' @export
+#' @encoding UTF-8
 arc_geo_categories <- function(
   category,
   x = NULL,
@@ -161,27 +160,9 @@ arc_geo_categories <- function(
     )
   }
 
-  # Prepare query.
-  # Vectorize categories.
-  cats <- unlist(strsplit(paste0(category, collapse = ","), ","))
-
-  base_tbl <- dplyr::tibble(
-    q_category = cats,
-    q_x = locs[1],
-    q_y = locs[2],
-    q_bbox_xmin = bbox[1],
-    q_bbox_ymin = bbox[2],
-    q_bbox_xmax = bbox[3],
-    q_bbox_ymax = bbox[4]
-  )
-
-  if (!anyNA(locs)) {
-    custom_query$location <- paste0(locs, collapse = ",")
-  }
-
-  if (!anyNA(bbox)) {
-    custom_query$searchExtent <- paste0(bbox, collapse = ",")
-  }
+  cats <- category_values(category)
+  base_tbl <- category_query_tbl(cats, locs, bbox)
+  custom_query <- add_category_query_params(custom_query, locs, bbox)
 
   if (is.null(name)) {
     name <- ""
@@ -208,11 +189,7 @@ arc_geo_categories <- function(
       message("(category: ", bs$q_category, ")")
     }
     end <- dplyr::bind_cols(bs, qry)
-
-    # Remove helper fields.
-    end <- end[, setdiff(names(end), "query")]
-
-    end
+    remove_query_col(end)
   })
 
   dplyr::bind_rows(api_res)
@@ -227,15 +204,14 @@ validate_location <- function(x = NULL, y = NULL) {
   }
   # Return NAs if both coordinates are missing.
   if (all(is.na(x), is.na(y))) {
-    return(c(NA, NA))
+    return(missing_location())
   }
 
   # Return NAs with a message if either coordinate is missing.
   if (anyNA(c(x, y))) {
-    message(
+    return(missing_location(
       "Either `x` or `y` is missing. The `location` argument will not be used."
-    )
-    return(c(NA, NA))
+    ))
   }
 
   # Check inputs.
@@ -247,64 +223,44 @@ validate_location <- function(x = NULL, y = NULL) {
   x <- x[1]
   y <- y[1]
 
-  # Restrict latitude.
-  y_cap <- pmax(pmin(y, 90), -90)
-
-  if (!identical(y_cap, y)) {
-    message("\nLatitudes have been restricted to [-90, 90].")
-  }
-
-  # Restrict longitude.
-  x_cap <- pmax(pmin(x, 180), -180)
-
-  if (!all(x_cap == x)) {
-    message("\nLongitudes have been restricted to [-180, 180].")
-  }
+  y_cap <- restrict_lat(y)
+  x_cap <- restrict_lon(x)
 
   c(x_cap, y_cap)
 }
 
 validate_bbox <- function(bbox = NULL) {
   if (is.null(bbox)) {
-    return(c(NA, NA, NA, NA))
+    return(missing_bbox())
   }
 
   # Return NAs with a message if any `bbox` value is missing.
   if (anyNA(bbox)) {
-    message("`bbox` has NA values. The `bbox` argument will not be used.")
-    return(c(NA, NA, NA, NA))
+    return(missing_bbox(
+      "`bbox` has NA values. The `bbox` argument will not be used."
+    ))
   }
 
   if (length(bbox) < 4) {
-    message(
+    return(missing_bbox(
       "`bbox` has fewer than 4 values. The `bbox` argument will not be used."
-    )
-    return(c(NA, NA, NA, NA))
+    ))
   }
 
   if (!is.numeric(bbox)) {
-    message("`bbox` is not numeric. The `bbox` argument will not be used.")
-    return(c(NA, NA, NA, NA))
+    return(missing_bbox(
+      "`bbox` is not numeric. The `bbox` argument will not be used."
+    ))
   }
 
   # Use only the first four `bbox` values.
   bbox <- bbox[1:4]
 
-  # Restrict longitude.
   xs <- bbox[c(1, 3)]
-  xs_cap <- pmax(pmin(xs, 180), -180)
+  xs_cap <- restrict_bbox_lon(xs)
 
-  if (!all(xs_cap == xs)) {
-    message("\n`bbox` xmin and xmax have been restricted to [-180, 180].")
-  }
-
-  # Restrict latitude.
   ys <- bbox[c(2, 4)]
-  ys_cap <- pmax(pmin(ys, 90), -90)
-
-  if (!all(ys_cap == ys)) {
-    message("\n`bbox` ymin and ymax have been restricted to [-90, 90].")
-  }
+  ys_cap <- restrict_bbox_lat(ys)
 
   c(xs_cap[1], ys_cap[1], xs_cap[2], ys_cap[2])
 }

--- a/R/arc_geo_multi.R
+++ b/R/arc_geo_multi.R
@@ -12,16 +12,6 @@
 #'   See **Details**.
 #' @inheritParams arc_geo
 #'
-#' @references
-#' [ArcGIS REST `findAddressCandidates`](`r arcurl("cand")`)
-#'
-#' @return
-#' ```{r child = "man/chunks/out1.Rmd"}
-#' ```
-#'
-#' The output also includes the input arguments as columns prefixed with `q_`
-#' to help track the results.
-#'
 #' @details
 #' See the [ArcGIS REST docs](`r arcurl("cand")`) for more information and
 #' valid values.
@@ -66,11 +56,19 @@
 #'
 #' @inheritSection arc_reverse_geo `outsr`
 #'
-#' @export
-#' @encoding UTF-8
+#' @return
+#' ```{r child = "man/chunks/out1.Rmd"}
+#' ```
+#'
+#' The output also includes the input arguments as columns prefixed with `q_`
+#' to help track the results.
+#'
+#' @references
+#' [ArcGIS REST `findAddressCandidates`](`r arcurl("cand")`).
+#'
+#' @family geocoding
 #'
 #' @seealso [tidygeocoder::geo()]
-#' @family geocoding
 #'
 #' @examplesIf arcgeocoder_check_access()
 #' \donttest{
@@ -108,6 +106,8 @@
 #'   select(lat, lon, CntryName, Region, LongLabel) |>
 #'   slice_head(n = 10)
 #' }
+#' @export
+#' @encoding UTF-8
 arc_geo_multi <- function(
   address = NULL,
   address2 = NULL,
@@ -145,13 +145,7 @@ arc_geo_multi <- function(
     countrycode
   )
 
-  if (limit > 50) {
-    message(paste(
-      "\nThe ArcGIS REST API provides a maximum of 50 results.",
-      "Your query may be incomplete."
-    ))
-    limit <- min(50, limit)
-  }
+  limit <- restrict_arc_limit(limit)
 
   # Deduplicate queries.
   init_key <- init_df
@@ -159,57 +153,35 @@ arc_geo_multi <- function(
   key <- key[!is.na(key)]
 
   if (length(key) == 0) {
-    stop("No address component provided. Provide at least one value.")
+    stop("No address component provided. Provide at least one non-NA value.")
   }
-
-  # Set progress bar.
-  ntot <- length(key)
-  # Show progress bar only for multiple queries.
-  progressbar <- all(progressbar, ntot > 1)
-  if (progressbar) {
-    pb <- txtProgressBar(min = 0, max = ntot, width = 50, style = 3)
-  }
-  seql <- seq(1, ntot, 1)
 
   # Add API arguments to the custom query.
-  if (isTRUE(full_results)) {
-    # Override any `outFields` parameter provided in `custom_query`.
-    custom_query$outFields <- "*"
-  }
+  custom_query <- add_find_address_params(
+    custom_query,
+    full_results = full_results,
+    outsr = outsr,
+    langcode = langcode,
+    category = category,
+    include_sourcecountry = FALSE
+  )
 
-  custom_query$outSR <- outsr
-  custom_query$langCode <- langcode
-  custom_query$category <- category
-
-  all_res <- lapply(seql, function(x) {
-    ad <- key[x]
-    if (progressbar) {
-      setTxtProgressBar(pb, x)
-    }
-    arc_geo_single(
-      address = ad,
-      lat,
-      long,
-      limit,
-      full_results,
-      return_addresses,
-      verbose,
-      custom_query,
-      singleline = FALSE
-    )
-  })
-  if (progressbar) {
-    close(pb)
-  }
-
-  all_res <- dplyr::bind_rows(all_res)
-  all_res <- dplyr::left_join(init_key, all_res, by = "query")
-
-  all_res[all_res == ""] <- NA
-  all_res
+  arc_geo_bulk(
+    key = key,
+    init_key = init_key,
+    lat = lat,
+    long = long,
+    limit = limit,
+    full_results = full_results,
+    return_addresses = return_addresses,
+    verbose = verbose,
+    custom_query = custom_query,
+    singleline = FALSE,
+    progressbar = progressbar
+  )
 }
 
-# Helper function.
+# Prepare multi-field input.
 input_multi <- function(
   address = NULL,
   address2 = NULL,
@@ -238,33 +210,29 @@ input_multi <- function(
   getlen <- lengths(multi_list)
   nolens <- getlen[getlen != 0]
   if (length(nolens) == 0) {
-    stop("No address component provided. Provide at least one value.")
+    stop("No address component provided. Provide at least one non-NA value.")
   }
   if (length(unique(nolens)) != 1) {
-    stop("When providing several components, their lengths must be the same.")
+    stop(paste0(
+      "When providing several address components, ",
+      "their lengths must be the same."
+    ))
   }
 
   the_df <- dplyr::bind_rows(multi_list[names(nolens)])
 
   # Build a query for each row.
-  nr <- seq_len(nrow(the_df))
-
-  query <- lapply(nr, function(x) {
-    id_row <- the_df[x, ]
-    id_row <- id_row[, as.logical(!is.na(id_row))]
-    if (ncol(id_row) == 0) {
-      qq <- NA
-    } else {
-      ll <- as.list(id_row)
-      qq <- paste0(names(ll), "=", ll, collapse = "&")
-    }
-
-    qq
-  })
+  query <- vapply(
+    seq_len(nrow(the_df)),
+    function(x) {
+      multi_row_query(the_df[x, ])
+    },
+    FUN.VALUE = character(1)
+  )
 
   names(the_df) <- paste0("q_", tolower(names(the_df)))
 
-  the_df$query <- unlist(query)
+  the_df$query <- query
 
   the_df
 }

--- a/R/arc_reverse_geo.R
+++ b/R/arc_reverse_geo.R
@@ -1,7 +1,7 @@
 #' Reverse geocode coordinates with the ArcGIS REST API
 #'
 #' @description
-#' Generates an address from a latitude and longitude. Latitudes must be in the
+#' Generates an address from a longitude and latitude. Latitudes must be in the
 #' range \eqn{\left[-90, 90 \right]} and longitudes in the range
 #' \eqn{\left[-180, 180 \right]}. This function returns the
 #' [tibble][tibble::tbl_df] associated with each query.
@@ -19,26 +19,23 @@
 #' @param progressbar Logical. If `TRUE`, show a progress bar for multiple
 #'   points.
 #' @param outsr The spatial reference of the `x` and `y` coordinates returned
-#'   by a geocode request. By default, it is `NULL` (i.e. the argument will not
-#'   be used in the query). See **Details** and [arc_spatial_references].
+#'   by a geocode request. By default, it is `NULL` (that is, the argument
+#'   will not be used in the query). See **Details** and
+#'   [arc_spatial_references].
 #' @param langcode Sets the language in which reverse-geocoded addresses are
 #'   returned.
 #' @param featuretypes This argument limits the possible match types returned.
-#'   By default, it is `NULL` (i.e. the argument will not be used in the query).
-#'   See **Details**.
+#'   By default, it is `NULL` (that is, the argument will not be used in the
+#'   query). See **Details**.
 #' @param locationtype Specifies whether the output geometry of
 #'   `featuretypes = "PointAddress"` or `featuretypes = "Subaddress"` matches
 #'   should be the rooftop point or street entrance location. Valid values are
-#'   `NULL` (i.e. not using the argument in the query), `"rooftop"` and
+#'   `NULL` (that is, not using the argument in the query), `"rooftop"` and
 #'   `"street"`.
 #' @param custom_query API-specific arguments to be used, passed as a named
 #'   list.
 #'
-#' @references
-#' [ArcGIS REST `reverseGeocode`](`r arcurl("rev")`).
-#'
 #' @details
-#'
 #' See the [ArcGIS REST docs](`r arcurl("rev")`) for more information and
 #' valid values.
 #'
@@ -46,7 +43,7 @@
 #'
 #' The spatial reference can be specified as a well-known ID (WKID). If not
 #' specified, the spatial reference of the output locations is the same as that
-#' of the service (WGS84, i.e. WKID = 4326).
+#' of the service (WGS84, that is, WKID = 4326).
 #'
 #' See [arc_spatial_references] for values and examples.
 #'
@@ -72,9 +69,15 @@
 #' See the details of the output in
 #' [ArcGIS REST API service output](`r arcurl("out")`).
 #'
+#' @references
+#' [ArcGIS REST `reverseGeocode`](`r arcurl("rev")`).
+#'
+#' @family geocoding
+#'
+#' @seealso [tidygeocoder::reverse_geo()]
+#'
 #' @examplesIf arcgeocoder_check_access()
 #' \donttest{
-#'
 #' arc_reverse_geo(x = -73.98586, y = 40.75728)
 #'
 #' # Several coordinates.
@@ -93,13 +96,8 @@
 #'
 #' dplyr::glimpse(sev)
 #' }
-#'
 #' @export
 #' @encoding UTF-8
-#'
-#' @family geocoding
-#' @seealso [tidygeocoder::reverse_geo()]
-#'
 arc_reverse_geo <- function(
   x,
   y,
@@ -123,19 +121,8 @@ arc_reverse_geo <- function(
     stop("`x` and `y` must have the same number of elements.")
   }
 
-  # Restrict latitude.
-  y_cap <- pmax(pmin(y, 90), -90)
-
-  if (!identical(y_cap, y)) {
-    message("\nLatitudes have been restricted to [-90, 90].")
-  }
-
-  # Restrict longitude.
-  x_cap <- pmax(pmin(x, 180), -180)
-
-  if (!all(x_cap == x)) {
-    message("\nLongitudes have been restricted to [-180, 180].")
-  }
+  y_cap <- restrict_lat(y)
+  x_cap <- restrict_lon(x)
 
   # Deduplicate coordinates before querying.
   init_key <- dplyr::tibble(
@@ -147,26 +134,16 @@ arc_reverse_geo <- function(
 
   key <- dplyr::distinct(init_key)
 
-  # Set progress bar.
-  ntot <- nrow(key)
-  # Show progress bar only for multiple coordinates.
-  progressbar <- all(progressbar, ntot > 1)
-  if (progressbar) {
-    pb <- txtProgressBar(min = 0, max = ntot, width = 50, style = 3)
-  }
-
-  seql <- seq(1, ntot, 1)
-
   # Add API arguments to the custom query.
-  custom_query$outSR <- outsr
-  custom_query$langCode <- langcode
-  custom_query$featureTypes <- featuretypes
-  custom_query$locationType <- locationtype
+  custom_query <- add_reverse_params(
+    custom_query,
+    outsr = outsr,
+    langcode = langcode,
+    featuretypes = featuretypes,
+    locationtype = locationtype
+  )
 
-  all_res <- lapply(seql, function(x) {
-    if (progressbar) {
-      setTxtProgressBar(pb, x)
-    }
+  all_res <- map_with_progress(seq_len(nrow(key)), progressbar, function(x, i) {
     rw <- key[x, ]
     res_single <- arc_reverse_geo_single(
       as.double(rw$y_cap_int),
@@ -181,9 +158,6 @@ arc_reverse_geo <- function(
 
     res_single
   })
-  if (progressbar) {
-    close(pb)
-  }
 
   all_res <- dplyr::bind_rows(all_res)
   all_res <- dplyr::left_join(
@@ -202,8 +176,7 @@ arc_reverse_geo <- function(
     all_res <- all_res[, !nm %in% c("x", "y")]
   }
 
-  all_res[all_res == ""] <- NA
-  all_res
+  empty_strings_to_na(all_res)
 }
 
 arc_reverse_geo_single <- function(
@@ -215,10 +188,7 @@ arc_reverse_geo_single <- function(
   custom_query = list()
 ) {
   # Step 1: Download ----
-  api <- paste0(
-    "https://geocode.arcgis.com/arcgis/rest/",
-    "services/World/GeocodeServer/reverseGeocode?"
-  )
+  api <- arc_endpoint_url("reverseGeocode")
 
   # Compose URL.
   url <- paste0(api, "location=", long_cap, ",", lat_cap, "&f=json")
@@ -249,7 +219,7 @@ arc_reverse_geo_single <- function(
       "\n",
       "No results for location: ",
       long_cap,
-      ",",
+      ", ",
       lat_cap,
       "\n",
       result_init$error$message,

--- a/R/arcgeocoder_check_access.R
+++ b/R/arcgeocoder_check_access.R
@@ -1,12 +1,12 @@
 #' Check access to ArcGIS REST
 #'
-#' @family api_management
-#'
 #' @description
-#' Checks whether \R has access to resources at the ArcGIS REST API
+#' Checks whether \R can access resources at the ArcGIS REST API
 #' <`r arcurl("over")`>.
 #'
 #' @return A logical value.
+#'
+#' @family api_management
 #'
 #' @examples
 #' \donttest{
@@ -16,10 +16,7 @@
 #' @export
 #' @encoding UTF-8
 arcgeocoder_check_access <- function() {
-  api <- paste0(
-    "https://geocode.arcgis.com/arcgis/rest/services/",
-    "World/GeocodeServer/reverseGeocode?"
-  )
+  api <- arc_endpoint_url("reverseGeocode")
 
   # Compose URL.
   url <- paste0(api, "location=0,0&f=json")
@@ -35,12 +32,7 @@ arcgeocoder_check_access <- function() {
   result_json <- jsonlite::fromJSON(destfile)
 
   # nocov start
-  if (result_json$location$x == 0) {
-    res <- TRUE
-  } else {
-    res <- FALSE
-  }
-  res
+  result_json$location$x == 0
   # nocov end
 }
 
@@ -63,40 +55,22 @@ skip_if_api_server <- function() {
 #' A wrapper around [utils::download.file()]. On warning or error, it retries
 #' the call.
 #'
-#' @family api_management
-#'
 #' @inheritParams utils::download.file
+#'
 #' @return A logical `TRUE` or `FALSE`.
 #'
-#' @keywords internal
+#' @family api_management
 #'
+#' @keywords internal
 #' @noRd
 arc_api_call <- function(url, destfile, quiet) {
   if (!quiet) {
-    decomp <- unlist(strsplit(url, "?", fixed = TRUE))
-    params <- unlist(strsplit(decomp[2], "&"))
-    url <- URLencode(url)
-    message(
-      "\nEntry point: ",
-      decomp[1],
-      "?\nParameters:\n",
-      paste0("   - ", params, collapse = "\n"),
-      "\nURL: ",
-      url
-    )
+    message_api_call(url)
   }
 
   url <- URLencode(url)
   # nocov start
-  dwn_res <- tryCatch(
-    download.file(url, destfile = destfile, quiet = TRUE, mode = "wb"),
-    warning = function(e) {
-      FALSE
-    },
-    error = function(e) {
-      FALSE
-    }
-  )
+  dwn_res <- arc_download_file(url, destfile)
   # nocov end
 
   # nocov start
@@ -106,21 +80,12 @@ arc_api_call <- function(url, destfile, quiet) {
     }
     Sys.sleep(1)
 
-    dwn_res <- tryCatch(
-      download.file(url, destfile = destfile, quiet = TRUE, mode = "wb"),
-      warning = function(e) {
-        FALSE
-      },
-      error = function(e) {
-        FALSE
-      }
-    )
+    dwn_res <- arc_download_file(url, destfile)
   }
 
   if (isFALSE(dwn_res)) {
     return(FALSE)
   }
-  res <- TRUE
-  res
+  TRUE
   # nocov end
 }

--- a/R/data.R
+++ b/R/data.R
@@ -1,22 +1,12 @@
 #' ArcGIS REST API category data
 #'
 #' @description
-#'
-#' Data set of available categories used to filter results provided by
+#' Dataset of available categories used to filter results provided by
 #' [arc_geo()], [arc_geo_multi()] and [arc_geo_categories()] in
 #' [tibble][tibble::tbl_df] format.
 #'
-#' @note Data extracted on **15 January 2026**.
-#'
-#' @source
-#' [ArcGIS REST Category filtering](`r arcurl("filt")`).
-#'
-#' @encoding UTF-8
-#'
 #' @name arc_categories
-#'
 #' @docType data
-#'
 #' @format
 #' A [tibble][tibble::tbl_df] with
 #' `r prettyNum(nrow(arcgeocoder::arc_categories), big.mark=",")` rows and
@@ -47,7 +37,12 @@
 #'
 #' The results show a list of categories with three different hierarchy levels
 #' (`level_1`, `level_2`, `level_3`). If a `level_1` category is requested
-#' (i.e. `POI`), the child categories may also be included in the results.
+#' (that is, `POI`), the child categories may also be included in the results.
+#'
+#' @source
+#' [ArcGIS REST Category filtering](`r arcurl("filt")`).
+#'
+#' @note Data extracted on **15 January 2026**.
 #'
 #' @family datasets
 #'
@@ -68,7 +63,7 @@
 #'
 #' dplyr::glimpse(sea_1)
 #'
-#' # An airport, but if we use categories...
+#' # Categories can disambiguate the result.
 #'
 #' sea_2 <- arc_geo("sea",
 #'   custom_query = list(outFields = c("LongLabel", "Type")),
@@ -86,27 +81,17 @@
 #'
 #' dplyr::glimpse(sea_3)
 #' }
+#' @encoding UTF-8
 NULL
 
 #' Esri (ArcGIS) spatial reference data
 #'
 #' @description
-#'
-#' Data set of available spatial references (CRS) in [tibble][tibble::tbl_df]
+#' Dataset of available spatial references (CRS) in [tibble][tibble::tbl_df]
 #' format.
 #'
-#' @note Data extracted on **15 January 2026**.
-#'
-#' @source
-#' [Esri Projection Engine
-#' factory](https://github.com/Esri/projection-engine-db-doc)
-#'
-#' @encoding UTF-8
-#'
 #' @name arc_spatial_references
-#'
 #' @docType data
-#'
 #' @format A [tibble][tibble::tbl_df] with
 #' `r prettyNum(nrow(arcgeocoder::arc_spatial_references), big.mark=",")` rows
 #' and fields:
@@ -124,11 +109,17 @@ NULL
 #' }
 #' @details
 #'
-#' This data set is useful when using the `outsr` argument.
+#' This dataset is useful when using the `outsr` argument.
 #'
 #' Some projection IDs have changed over time. For example, Web Mercator
 #' `wkid = 102100` is deprecated and is currently `wkid = 3857`. However, both
 #' values work and return similar results.
+#'
+#' @source
+#' [Esri Projection Engine
+#' factory](https://github.com/Esri/projection-engine-db-doc)
+#'
+#' @note Data extracted on **15 January 2026**.
 #'
 #' @family datasets
 #'
@@ -167,4 +158,5 @@ NULL
 #' # Or use WKT.
 #' try(sf::st_crs(wkid$wkt))
 #' }
+#' @encoding UTF-8
 NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,6 +26,321 @@ is_named <- function(x) {
   TRUE
 }
 
+restrict_arc_limit <- function(limit) {
+  if (limit > 50) {
+    message(paste0(
+      "\nThe ArcGIS REST API provides a maximum of 50 results.",
+      " Only the first 50 results will be requested."
+    ))
+    limit <- min(50, limit)
+  }
+
+  limit
+}
+
+progress_control <- function(progressbar, total) {
+  show_progress <- all(progressbar, total > 1)
+
+  pb <- NULL
+  if (show_progress) {
+    pb <- txtProgressBar(min = 0, max = total, width = 50, style = 3)
+  }
+
+  list(show = show_progress, bar = pb, seq = seq_len(total))
+}
+
+tick_progress <- function(progress, value) {
+  if (progress$show) {
+    setTxtProgressBar(progress$bar, value)
+  }
+}
+
+close_progress <- function(progress) {
+  if (progress$show) {
+    close(progress$bar)
+  }
+}
+
+map_with_progress <- function(x, progressbar, fun) {
+  progress <- progress_control(progressbar, length(x))
+  on.exit(close_progress(progress), add = TRUE)
+
+  lapply(progress$seq, function(i) {
+    tick_progress(progress, i)
+    fun(x[[i]], i)
+  })
+}
+
+add_find_address_params <- function(
+  custom_query,
+  full_results = FALSE,
+  sourcecountry = NULL,
+  outsr = NULL,
+  langcode = NULL,
+  category = NULL,
+  include_sourcecountry = TRUE
+) {
+  if (isTRUE(full_results)) {
+    # Override any `outFields` parameter provided in `custom_query`.
+    custom_query$outFields <- "*"
+  }
+
+  if (include_sourcecountry) {
+    custom_query$sourceCountry <- sourcecountry
+  }
+  custom_query$outSR <- outsr
+  custom_query$langCode <- langcode
+  custom_query$category <- category
+
+  custom_query
+}
+
+add_reverse_params <- function(
+  custom_query,
+  outsr = NULL,
+  langcode = NULL,
+  featuretypes = NULL,
+  locationtype = NULL
+) {
+  custom_query$outSR <- outsr
+  custom_query$langCode <- langcode
+  custom_query$featureTypes <- featuretypes
+  custom_query$locationType <- locationtype
+
+  custom_query
+}
+
+restrict_range <- function(
+  x,
+  min_value,
+  max_value,
+  message_text,
+  use_identical = FALSE
+) {
+  capped <- pmax(pmin(x, max_value), min_value)
+
+  has_changed <- !all(capped == x)
+  if (use_identical) {
+    has_changed <- !identical(capped, x)
+  }
+
+  if (has_changed) {
+    message(message_text)
+  }
+
+  capped
+}
+
+restrict_lat <- function(x) {
+  restrict_range(
+    x,
+    min_value = -90,
+    max_value = 90,
+    message_text = "\nLatitudes have been restricted to [-90, 90].",
+    use_identical = TRUE
+  )
+}
+
+restrict_lon <- function(x) {
+  restrict_range(
+    x,
+    min_value = -180,
+    max_value = 180,
+    message_text = "\nLongitudes have been restricted to [-180, 180]."
+  )
+}
+
+restrict_bbox_lat <- function(x) {
+  restrict_range(
+    x,
+    min_value = -90,
+    max_value = 90,
+    message_text = "\n`bbox` ymin and ymax have been restricted to [-90, 90]."
+  )
+}
+
+restrict_bbox_lon <- function(x) {
+  restrict_range(
+    x,
+    min_value = -180,
+    max_value = 180,
+    message_text = "\n`bbox` xmin and xmax have been restricted to [-180, 180]."
+  )
+}
+
+missing_location <- function(message_text = NULL) {
+  if (!is.null(message_text)) {
+    message(message_text)
+  }
+
+  c(NA, NA)
+}
+
+missing_bbox <- function(message_text = NULL) {
+  if (!is.null(message_text)) {
+    message(message_text)
+  }
+
+  c(NA, NA, NA, NA)
+}
+
+arc_endpoint_url <- function(endpoint) {
+  paste0(
+    "https://geocode.arcgis.com/arcgis/rest/",
+    "services/World/GeocodeServer/",
+    endpoint,
+    "?"
+  )
+}
+
+arc_download_file <- function(url, destfile) {
+  # nocov start
+  tryCatch(
+    download.file(url, destfile = destfile, quiet = TRUE, mode = "wb"),
+    warning = function(e) {
+      FALSE
+    },
+    error = function(e) {
+      FALSE
+    }
+  )
+  # nocov end
+}
+
+message_api_call <- function(url) {
+  decomp <- unlist(strsplit(url, "?", fixed = TRUE))
+  params <- unlist(strsplit(decomp[2], "&"))
+  encoded_url <- URLencode(url)
+
+  message(
+    "\nEntry point: ",
+    decomp[1],
+    "?\nParameters:\n",
+    paste0("   - ", params, collapse = "\n"),
+    "\nURL: ",
+    encoded_url
+  )
+}
+
+select_unique_cols <- function(x, cols) {
+  x[, unique(cols)]
+}
+
+empty_strings_to_na <- function(x) {
+  x[x == ""] <- NA
+  x
+}
+
+arc_geo_bulk <- function(
+  key,
+  init_key,
+  lat,
+  long,
+  limit,
+  full_results,
+  return_addresses,
+  verbose,
+  custom_query,
+  singleline,
+  progressbar
+) {
+  all_res <- map_with_progress(key, progressbar, function(ad, i) {
+    arc_geo_single(
+      address = ad,
+      lat,
+      long,
+      limit,
+      full_results,
+      return_addresses,
+      verbose,
+      custom_query,
+      singleline = singleline
+    )
+  })
+
+  all_res <- dplyr::bind_rows(all_res)
+  all_res <- dplyr::left_join(init_key, all_res, by = "query")
+
+  empty_strings_to_na(all_res)
+}
+
+category_values <- function(category) {
+  unlist(strsplit(paste0(category, collapse = ","), ","))
+}
+
+category_query_tbl <- function(categories, locs, bbox) {
+  dplyr::tibble(
+    q_category = categories,
+    q_x = locs[1],
+    q_y = locs[2],
+    q_bbox_xmin = bbox[1],
+    q_bbox_ymin = bbox[2],
+    q_bbox_xmax = bbox[3],
+    q_bbox_ymax = bbox[4]
+  )
+}
+
+add_category_query_params <- function(custom_query, locs, bbox) {
+  if (!anyNA(locs)) {
+    custom_query$location <- paste0(locs, collapse = ",")
+  }
+
+  if (!anyNA(bbox)) {
+    custom_query$searchExtent <- paste0(bbox, collapse = ",")
+  }
+
+  custom_query
+}
+
+remove_query_col <- function(x) {
+  x[, setdiff(names(x), "query")]
+}
+
+rename_exact <- function(x, old, new) {
+  names(x) <- gsub(paste0("^", old, "$"), new, names(x))
+  x
+}
+
+geo_output_cols <- function(
+  x,
+  colstokeep,
+  full_results = TRUE,
+  return_addresses = TRUE
+) {
+  out_cols <- colstokeep
+
+  if (return_addresses || full_results) {
+    out_cols <- c(out_cols, names(x))
+  }
+
+  out_cols
+}
+
+reverse_output_cols <- function(
+  x,
+  colstokeep,
+  full_results = FALSE
+) {
+  out_cols <- colstokeep
+
+  if (full_results) {
+    out_cols <- c(out_cols, "lat", "lon", names(x))
+  }
+
+  out_cols
+}
+
+multi_row_query <- function(row) {
+  row <- row[, as.logical(!is.na(row)), drop = FALSE]
+
+  if (ncol(row) == 0) {
+    return(NA_character_)
+  }
+
+  row <- as.list(row)
+  paste0(names(row), "=", row, collapse = "&")
+}
+
 # Specific ----
 unnest_reverse <- function(x) {
   x_add <- x$address
@@ -87,13 +402,8 @@ keep_names_rev <- function(
 ) {
   names(x) <- gsub("address", address, names(x), fixed = TRUE)
 
-  out_cols <- colstokeep
-  if (full_results) {
-    out_cols <- c(out_cols, "lat", "lon", names(x))
-  }
-
-  out_cols <- unique(out_cols)
-  out <- x[, out_cols]
+  out_cols <- reverse_output_cols(x, colstokeep, full_results)
+  out <- select_unique_cols(x, out_cols)
 
   out
 }
@@ -106,21 +416,11 @@ keep_names <- function(
   return_addresses = TRUE,
   colstokeep = c("query", lat, lon)
 ) {
-  names(x) <- gsub("^lon$", lon, names(x))
-  names(x) <- gsub("^lat$", lat, names(x))
+  x <- rename_exact(x, "lon", lon)
+  x <- rename_exact(x, "lat", lat)
 
-  out_cols <- colstokeep
-  out_cols <- c(out_cols, names(x))
-
-  if (!return_addresses) {
-    out_cols <- colstokeep
-  }
-  if (full_results) {
-    out_cols <- c(out_cols, names(x))
-  }
-
-  out_cols <- unique(out_cols)
-  out <- x[, out_cols]
+  out_cols <- geo_output_cols(x, colstokeep, full_results, return_addresses)
+  out <- select_unique_cols(x, out_cols)
 
   out
 }

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ A BibTeX entry for LaTeX users is
       doi = {10.32614/CRAN.package.arcgeocoder},
       author = {Diego Hernangómez},
       year = {2026},
-      version = {0.4.0},
+      version = {0.4.0.9000},
       url = {https://dieghernan.github.io/arcgeocoder/},
       abstract = {Lightweight interface for geocoding addresses and reverse geocoding locations around the world with the ArcGIS REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.},
     }

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 <!-- badges: end -->
 
 The goal of **arcgeocoder** is to provide a lightweight interface for
-geocoding addresses and reverse geocoding locations through the [ArcGIS
-REST API geocoding
+geocoding addresses and reverse geocoding coordinates through the
+[ArcGIS REST API geocoding
 service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm).
 
 The full site with examples and vignettes is available at
@@ -39,8 +39,8 @@ without depending on additional HTTP packages such as **curl**. In some
 situations, **curl** may not be available or accessible, so
 **arcgeocoder** uses base functions to avoid this limitation.
 
-The interface of **arcgeocoder** is designed to make the API features
-easier to access. The API endpoints used by **arcgeocoder** are
+The interface of **arcgeocoder** is designed to make ArcGIS geocoding
+features easier to access. The API endpoints used by **arcgeocoder** are
 `findAddressCandidates` and `reverseGeocode`, which can be accessed
 <u>**without**</u> an <u>**API key**</u>.
 
@@ -202,7 +202,7 @@ eiffel_tower |>
 #>   <dbl> <dbl> <chr>                                                             
 #> 1  2.29  48.9 Tour Eiffel, 3 Rue de l'Université, 75007, 7e Arrondissement, Par…
 
-# Use `lon` and `lat` to boost the search with `category = "Food"`.
+# Use `lon` and `lat` as a reference location for `category = "Food"`.
 food_eiffel <- arc_geo_categories(
   "Food",
   x = eiffel_tower$lon,
@@ -228,7 +228,7 @@ ggplot(eiffel_tower, aes(x, y)) +
 <img src="man/figures/README-eiffel-1.png" style="width:100.0%"
 alt="Example: Food places near the Eiffel Tower" />
 
-### arcgeocoder and r-spatial
+### arcgeocoder and spatial data
 
 It is straightforward to convert **arcgeocoder** results to an **sf**
 object:
@@ -297,7 +297,7 @@ A BibTeX entry for LaTeX users is
       year = {2026},
       version = {0.4.0.9000},
       url = {https://dieghernan.github.io/arcgeocoder/},
-      abstract = {Lightweight interface for geocoding addresses and reverse geocoding locations around the world with the ArcGIS REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.},
+      abstract = {Lightweight interface for geocoding addresses and reverse geocoding coordinates around the world with the ArcGIS REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.},
     }
 
 ## References

--- a/README.qmd
+++ b/README.qmd
@@ -41,7 +41,7 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 <!-- badges: end -->
 
 The goal of **arcgeocoder** is to provide a lightweight interface for
-geocoding addresses and reverse geocoding locations through the
+geocoding addresses and reverse geocoding coordinates through the
 [ArcGIS REST API geocoding service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm).
 
 The full site with examples and vignettes is available at
@@ -55,9 +55,10 @@ depending on additional HTTP packages such as **curl**. In some situations,
 **curl** may not be available or accessible, so **arcgeocoder** uses base
 functions to avoid this limitation.
 
-The interface of **arcgeocoder** is designed to make the API features easier to
-access. The API endpoints used by **arcgeocoder** are `findAddressCandidates`
-and `reverseGeocode`, which can be accessed [**without**]{.underline} an
+The interface of **arcgeocoder** is designed to make ArcGIS geocoding features
+easier to access. The API endpoints used by **arcgeocoder** are
+`findAddressCandidates` and `reverseGeocode`, which can be accessed
+[**without**]{.underline} an
 [**API key**]{.underline}.
 
 ## Recommended packages
@@ -205,7 +206,7 @@ eiffel_tower <- arc_geo_multi(
 eiffel_tower |>
   select(lon, lat, LongLabel)
 
-# Use `lon` and `lat` to boost the search with `category = "Food"`.
+# Use `lon` and `lat` as a reference location for `category = "Food"`.
 food_eiffel <- arc_geo_categories(
   "Food",
   x = eiffel_tower$lon,
@@ -228,7 +229,7 @@ ggplot(eiffel_tower, aes(x, y)) +
   )
 ```
 
-### arcgeocoder and r-spatial
+### arcgeocoder and spatial data
 
 It is straightforward to convert **arcgeocoder** results to an **sf** object:
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/dieghernan/arcgeocoder",
   "issueTracker": "https://github.com/dieghernan/arcgeocoder/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.4.0",
+  "version": "0.4.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -172,7 +172,7 @@
   },
   "applicationCategory": "cartography",
   "keywords": ["r", "geocoding", "arcgis", "address", "reverse-geocoding", "rstats", "r-package", "api-wrapper", "api-rest", "arcgis-api", "cran-r", "gis", "cran"],
-  "fileSize": "418.233KB",
+  "fileSize": "418.303KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "arcgeocoder",
-  "description": "Lightweight interface for geocoding addresses and reverse geocoding locations around the world with the 'ArcGIS' REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.",
+  "description": "Lightweight interface for geocoding addresses and reverse geocoding coordinates around the world with the 'ArcGIS' REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.",
   "name": "arcgeocoder: Geocode with the 'ArcGIS' REST API Service",
   "relatedLink": ["https://dieghernan.github.io/arcgeocoder/", "https://CRAN.R-project.org/package=arcgeocoder"],
   "codeRepository": "https://github.com/dieghernan/arcgeocoder",
@@ -172,7 +172,7 @@
   },
   "applicationCategory": "cartography",
   "keywords": ["r", "geocoding", "arcgis", "address", "reverse-geocoding", "rstats", "r-package", "api-wrapper", "api-rest", "arcgis-api", "cran-r", "gis", "cran"],
-  "fileSize": "418.303KB",
+  "fileSize": "421.565KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -18,6 +18,7 @@ OpenStreetMap
 Ozero
 POIs
 Possenriede
+README
 Redlands
 Shybyndy
 StreetAddress
@@ -32,9 +33,7 @@ doi
 et
 geocode
 geocoded
-geocoder
 geocoding
-geospatial
 ggplot
 latestWkid
 lon
@@ -42,6 +41,7 @@ maptiles
 nominatimlite
 pkgdown
 reactable
+roxygen
 subregion
 subunit
 terra

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -14,7 +14,7 @@
         "familyName": "Hernangómez",
         "givenName": "Diego"
       },
-      "description": "Lightweight interface for geocoding addresses and reverse geocoding locations around the world with the 'ArcGIS' REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.",
+      "description": "Lightweight interface for geocoding addresses and reverse geocoding coordinates around the world with the 'ArcGIS' REST API service <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.",
       "license": "https://spdx.org/licenses/MIT",
       "name": "arcgeocoder: Geocode with the 'ArcGIS' REST API Service",
       "programmingLanguage": {

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -29,7 +29,7 @@
         "url": "https://cran.r-project.org"
       },
       "runtimePlatform": "R version 4.6.0 (2026-04-24 ucrt)",
-      "version": "0.4.0"
+      "version": "0.4.0.9000"
     },
     {
       "id": "https://doi.org/10.32614/CRAN.package.arcgeocoder",

--- a/man/arc_categories.Rd
+++ b/man/arc_categories.Rd
@@ -19,7 +19,7 @@ fields:
 \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm}{ArcGIS REST Category filtering}.
 }
 \description{
-Data set of available categories used to filter results provided by
+Dataset of available categories used to filter results provided by
 \code{\link[=arc_geo]{arc_geo()}}, \code{\link[=arc_geo_multi]{arc_geo_multi()}} and \code{\link[=arc_geo_categories]{arc_geo_categories()}} in
 \link[tibble:tbl_df]{tibble} format.
 }
@@ -43,7 +43,7 @@ false-positive matches and potentially speeding up the search process.
 
 The results show a list of categories with three different hierarchy levels
 (\code{level_1}, \code{level_2}, \code{level_3}). If a \code{level_1} category is requested
-(i.e. \code{POI}), the child categories may also be included in the results.
+(that is, \code{POI}), the child categories may also be included in the results.
 }
 \note{
 Data extracted on \strong{15 January 2026}.
@@ -64,7 +64,7 @@ sea_1 <- arc_geo("sea",
 
 dplyr::glimpse(sea_1)
 
-# An airport, but if we use categories...
+# Categories can disambiguate the result.
 
 sea_2 <- arc_geo("sea",
   custom_query = list(outFields = c("LongLabel", "Type")),

--- a/man/arc_geo.Rd
+++ b/man/arc_geo.Rd
@@ -45,8 +45,9 @@ output.}
 points.}
 
 \item{outsr}{The spatial reference of the \code{x} and \code{y} coordinates returned
-by a geocode request. By default, it is \code{NULL} (i.e. the argument will not
-be used in the query). See \strong{Details} and \link{arc_spatial_references}.}
+by a geocode request. By default, it is \code{NULL} (that is, the argument
+will not be used in the query). See \strong{Details} and
+\link{arc_spatial_references}.}
 
 \item{langcode}{Sets the language in which reverse-geocoded addresses are
 returned.}
@@ -60,14 +61,14 @@ accepted (e.g. \code{c("Cinema", "Museum")}). See \link{arc_categories}.}
 \item{custom_query}{Additional API parameters as named list values.}
 }
 \value{
-A \link[tibble:tbl_df]{tibble} object with the results. See output details in  \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
+A \link[tibble:tbl_df]{tibble} object with the results. See output details in \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
 }
 \description{
-Geocodes addresses given as character values and returns the
+Geocodes addresses supplied as character values and returns the
 \link[tibble:tbl_df]{tibble} associated with each query.
 
 This function uses the \code{SingleLine} approach detailed in the
-\href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm}{ArcGIS REST docs}. For multi-field queries (i.e.
+\href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm}{ArcGIS REST docs}. For multi-field queries (that is,
 using specific address components), use \code{\link[=arc_geo_multi]{arc_geo_multi()}}.
 }
 \details{
@@ -77,7 +78,7 @@ valid values.
 \section{\code{outsr}}{
 The spatial reference can be specified as a well-known ID (WKID). If not
 specified, the spatial reference of the output locations is the same as that
-of the service (WGS84, i.e. WKID = 4326).
+of the service (WGS84, that is, WKID = 4326).
 
 See \link{arc_spatial_references} for values and examples.
 }

--- a/man/arc_geo_categories.Rd
+++ b/man/arc_geo_categories.Rd
@@ -43,8 +43,8 @@ desired results.}
 
 \item{long}{Longitude column name in the output data (default \code{"lon"}).}
 
-\item{limit}{Maximum number of results per query. ArcGIS API limits a single
-request to 50 results.}
+\item{limit}{Maximum number of results per query. The ArcGIS REST API limits
+a single request to 50 results.}
 
 \item{full_results}{Logical. If \code{TRUE}, return all available API fields
 via \verb{outFields=*}. Default is \code{FALSE}.}
@@ -59,14 +59,15 @@ via \verb{outFields=*}. Default is \code{FALSE}.}
     \item{\code{sourcecountry}}{Country filter using ISO codes (e.g. \code{"USA"}).
 Multiple values can be supplied as a comma-separated string.}
     \item{\code{outsr}}{The spatial reference of the \code{x} and \code{y} coordinates returned
-by a geocode request. By default, it is \code{NULL} (i.e. the argument will not
-be used in the query). See \strong{Details} and \link{arc_spatial_references}.}
+by a geocode request. By default, it is \code{NULL} (that is, the argument
+will not be used in the query). See \strong{Details} and
+\link{arc_spatial_references}.}
     \item{\code{langcode}}{Sets the language in which reverse-geocoded addresses are
 returned.}
   }}
 }
 \value{
-A \link[tibble:tbl_df]{tibble} object with the results. See output details in  \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
+A \link[tibble:tbl_df]{tibble} object with the results. See output details in \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
 }
 \description{
 This function extracts places with a given category or list of categories
@@ -97,7 +98,7 @@ separated by commas (\code{"Cinema,Museum"}), which is treated internally as
 \section{\code{outsr}}{
 The spatial reference can be specified as a well-known ID (WKID). If not
 specified, the spatial reference of the output locations is the same as that
-of the service (WGS84, i.e. WKID = 4326).
+of the service (WGS84, that is, WKID = 4326).
 
 See \link{arc_spatial_references} for values and examples.
 }

--- a/man/arc_geo_multi.Rd
+++ b/man/arc_geo_multi.Rd
@@ -55,8 +55,9 @@ output.}
 points.}
 
 \item{outsr}{The spatial reference of the \code{x} and \code{y} coordinates returned
-by a geocode request. By default, it is \code{NULL} (i.e. the argument will not
-be used in the query). See \strong{Details} and \link{arc_spatial_references}.}
+by a geocode request. By default, it is \code{NULL} (that is, the argument
+will not be used in the query). See \strong{Details} and
+\link{arc_spatial_references}.}
 
 \item{langcode}{Sets the language in which reverse-geocoded addresses are
 returned.}
@@ -67,7 +68,7 @@ accepted (e.g. \code{c("Cinema", "Museum")}). See \link{arc_categories}.}
 \item{custom_query}{Additional API parameters as named list values.}
 }
 \value{
-A \link[tibble:tbl_df]{tibble} object with the results. See output details in  \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
+A \link[tibble:tbl_df]{tibble} object with the results. See output details in \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
 
 The output also includes the input arguments as columns prefixed with \code{q_}
 to help track the results.
@@ -124,7 +125,7 @@ country code or the three-character country code.
 \section{\code{outsr}}{
 The spatial reference can be specified as a well-known ID (WKID). If not
 specified, the spatial reference of the output locations is the same as that
-of the service (WGS84, i.e. WKID = 4326).
+of the service (WGS84, that is, WKID = 4326).
 
 See \link{arc_spatial_references} for values and examples.
 }
@@ -169,7 +170,7 @@ simple3 |>
 \dontshow{\}) # examplesIf}
 }
 \references{
-\href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm}{ArcGIS REST \code{findAddressCandidates}}
+\href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm}{ArcGIS REST \code{findAddressCandidates}}.
 }
 \seealso{
 \code{\link[tidygeocoder:geo]{tidygeocoder::geo()}}

--- a/man/arc_reverse_geo.Rd
+++ b/man/arc_reverse_geo.Rd
@@ -41,20 +41,21 @@ results.}
 points.}
 
 \item{outsr}{The spatial reference of the \code{x} and \code{y} coordinates returned
-by a geocode request. By default, it is \code{NULL} (i.e. the argument will not
-be used in the query). See \strong{Details} and \link{arc_spatial_references}.}
+by a geocode request. By default, it is \code{NULL} (that is, the argument
+will not be used in the query). See \strong{Details} and
+\link{arc_spatial_references}.}
 
 \item{langcode}{Sets the language in which reverse-geocoded addresses are
 returned.}
 
 \item{featuretypes}{This argument limits the possible match types returned.
-By default, it is \code{NULL} (i.e. the argument will not be used in the query).
-See \strong{Details}.}
+By default, it is \code{NULL} (that is, the argument will not be used in the
+query). See \strong{Details}.}
 
 \item{locationtype}{Specifies whether the output geometry of
 \code{featuretypes = "PointAddress"} or \code{featuretypes = "Subaddress"} matches
 should be the rooftop point or street entrance location. Valid values are
-\code{NULL} (i.e. not using the argument in the query), \code{"rooftop"} and
+\code{NULL} (that is, not using the argument in the query), \code{"rooftop"} and
 \code{"street"}.}
 
 \item{custom_query}{API-specific arguments to be used, passed as a named
@@ -70,7 +71,7 @@ See the details of the output in
 \href{https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm}{ArcGIS REST API service output}.
 }
 \description{
-Generates an address from a latitude and longitude. Latitudes must be in the
+Generates an address from a longitude and latitude. Latitudes must be in the
 range \eqn{\left[-90, 90 \right]} and longitudes in the range
 \eqn{\left[-180, 180 \right]}. This function returns the
 \link[tibble:tbl_df]{tibble} associated with each query.
@@ -82,7 +83,7 @@ valid values.
 \section{\code{outsr}}{
 The spatial reference can be specified as a well-known ID (WKID). If not
 specified, the spatial reference of the output locations is the same as that
-of the service (WGS84, i.e. WKID = 4326).
+of the service (WGS84, that is, WKID = 4326).
 
 See \link{arc_spatial_references} for values and examples.
 }
@@ -103,7 +104,6 @@ It is also possible to use several values as a vector
 \examples{
 \dontshow{if (arcgeocoder_check_access()) withAutoprint(\{ # examplesIf}
 \donttest{
-
 arc_reverse_geo(x = -73.98586, y = 40.75728)
 
 # Several coordinates.

--- a/man/arc_spatial_references.Rd
+++ b/man/arc_spatial_references.Rd
@@ -26,11 +26,11 @@ working with \CRANpkg{sf} or \CRANpkg{terra}.}
 \href{https://github.com/Esri/projection-engine-db-doc}{Esri Projection Engine factory}
 }
 \description{
-Data set of available spatial references (CRS) in \link[tibble:tbl_df]{tibble}
+Dataset of available spatial references (CRS) in \link[tibble:tbl_df]{tibble}
 format.
 }
 \details{
-This data set is useful when using the \code{outsr} argument.
+This dataset is useful when using the \code{outsr} argument.
 
 Some projection IDs have changed over time. For example, Web Mercator
 \code{wkid = 102100} is deprecated and is currently \code{wkid = 3857}. However, both

--- a/man/arcgeocoder-package.Rd
+++ b/man/arcgeocoder-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Lightweight interface for geocoding addresses and reverse geocoding locations around the world with the 'ArcGIS' REST API service \url{https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm}. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.
+Lightweight interface for geocoding addresses and reverse geocoding coordinates around the world with the 'ArcGIS' REST API service \url{https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm}. Address text can be converted to location candidates and coordinates can be converted into addresses. No API key is required.
 }
 \seealso{
 Useful links:

--- a/man/arcgeocoder_check_access.Rd
+++ b/man/arcgeocoder_check_access.Rd
@@ -11,7 +11,7 @@ arcgeocoder_check_access()
 A logical value.
 }
 \description{
-Checks whether \R has access to resources at the ArcGIS REST API
+Checks whether \R can access resources at the ArcGIS REST API
 \url{https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm}.
 }
 \examples{

--- a/man/chunks/out1.Rmd
+++ b/man/chunks/out1.Rmd
@@ -4,7 +4,7 @@
 cat(paste0(
   "A [tibble][tibble::tbl_df] object with the results. ",
   "See output details in ",
-  " [ArcGIS REST API service output](",
+  "[ArcGIS REST API service output](",
   arcgeocoder:::arcurl("out"), ")."
 ))
 ```

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -20,7 +20,7 @@ home:
   title: arcgeocoder | Geocoding with the ArcGIS REST API service
   description: >
     Lightweight interface for geocoding addresses and reverse geocoding
-    locations with the ArcGIS REST API service, with no API key required.
+    coordinates with the ArcGIS REST API service, with no API key required.
 authors:
   Diego Hernangómez:
     href: https://dieghernan.github.io/
@@ -39,6 +39,12 @@ reference:
     references.
   contents:
   - has_concept("datasets")
+
+- title: API management
+  desc: >
+    Helpers for checking access to the ArcGIS REST API.
+  contents:
+  - arcgeocoder_check_access
 
 - title: About the package
   desc: Package-level documentation and metadata.

--- a/tests/testthat/_snaps/arc_geo.md
+++ b/tests/testthat/_snaps/arc_geo.md
@@ -4,7 +4,7 @@
       out <- arc_geo("Madrid", limit = 200)
     Message
       
-      The ArcGIS REST API provides a maximum of 50 results. Your query may be incomplete.
+      The ArcGIS REST API provides a maximum of 50 results. Only the first 50 results will be requested.
 
 ---
 

--- a/tests/testthat/_snaps/arc_geo_multi.md
+++ b/tests/testthat/_snaps/arc_geo_multi.md
@@ -4,7 +4,7 @@
       out <- arc_geo_multi("Madrid", limit = 200)
     Message
       
-      The ArcGIS REST API provides a maximum of 50 results. Your query may be incomplete.
+      The ArcGIS REST API provides a maximum of 50 results. Only the first 50 results will be requested.
 
 ---
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -33,3 +33,21 @@ test_that("names", {
   l <- list(NA)
   expect_false(is_named(l))
 })
+
+test_that("multi-field query rows", {
+  row <- dplyr::tibble(
+    address = "Calle Mayor",
+    city = NA_character_,
+    countryCode = "ESP"
+  )
+  expect_identical(
+    multi_row_query(row),
+    "address=Calle Mayor&countryCode=ESP"
+  )
+
+  empty_row <- dplyr::tibble(
+    address = NA_character_,
+    city = NA_character_
+  )
+  expect_identical(multi_row_query(empty_row), NA_character_)
+})

--- a/vignettes/arcgeocoder.qmd
+++ b/vignettes/arcgeocoder.qmd
@@ -15,7 +15,7 @@ tbl-cap-location: bottom
 
 
 The goal of **arcgeocoder** is to provide a lightweight interface for
-geocoding addresses and reverse geocoding locations through the
+geocoding addresses and reverse geocoding coordinates through the
 [ArcGIS REST API geocoding service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm).
 
 The full site with examples and vignettes is available at
@@ -29,9 +29,10 @@ depending on additional HTTP packages such as **curl**. In some situations,
 **curl** may not be available or accessible, so **arcgeocoder** uses base
 functions to avoid this limitation.
 
-The interface of **arcgeocoder** is designed to make the API features easier to
-access. The API endpoints used by **arcgeocoder** are `findAddressCandidates`
-and `reverseGeocode`, which can be accessed without an API key.
+The interface of **arcgeocoder** is designed to make ArcGIS geocoding features
+easier to access. The API endpoints used by **arcgeocoder** are
+`findAddressCandidates` and `reverseGeocode`, which can be accessed without an
+API key.
 
 ## Recommended packages
 
@@ -156,7 +157,7 @@ eiffel_tower |>
 #>   <dbl> <dbl> <chr>                                                                          
 #> 1  2.29  48.9 Tour Eiffel, 3 Rue de l'Université, 75007, 7e Arrondissement, Paris, Île-de-Fr…
 
-# Use `lon` and `lat` to boost the search with `category = "Food"`.
+# Use `lon` and `lat` as a reference location for `category = "Food"`.
 food_eiffel <- arc_geo_categories(
   "Food",
   x = eiffel_tower$lon,

--- a/vignettes/arcgeocoder.qmd
+++ b/vignettes/arcgeocoder.qmd
@@ -152,9 +152,9 @@ eiffel_tower <- arc_geo_multi(
 eiffel_tower |>
   select(lon, lat, LongLabel)
 #> # A tibble: 1 × 3
-#>     lon   lat LongLabel                                                                        
-#>   <dbl> <dbl> <chr>                                                                            
-#> 1  2.29  48.9 Tour Eiffel, 3 Rue de l'Université, 75007, 7e Arrondissement, Paris, Île-de-Fran…
+#>     lon   lat LongLabel                                                                      
+#>   <dbl> <dbl> <chr>                                                                          
+#> 1  2.29  48.9 Tour Eiffel, 3 Rue de l'Université, 75007, 7e Arrondissement, Paris, Île-de-Fr…
 
 # Use `lon` and `lat` to boost the search with `category = "Food"`.
 food_eiffel <- arc_geo_categories(

--- a/vignettes/arcgeocoder.qmd.orig
+++ b/vignettes/arcgeocoder.qmd.orig
@@ -28,7 +28,7 @@ library(arcgeocoder)
 ```
 
 The goal of **arcgeocoder** is to provide a lightweight interface for
-geocoding addresses and reverse geocoding locations through the
+geocoding addresses and reverse geocoding coordinates through the
 [ArcGIS REST API geocoding service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm).
 
 The full site with examples and vignettes is available at
@@ -42,9 +42,10 @@ depending on additional HTTP packages such as **curl**. In some situations,
 **curl** may not be available or accessible, so **arcgeocoder** uses base
 functions to avoid this limitation.
 
-The interface of **arcgeocoder** is designed to make the API features easier to
-access. The API endpoints used by **arcgeocoder** are `findAddressCandidates`
-and `reverseGeocode`, which can be accessed without an API key.
+The interface of **arcgeocoder** is designed to make ArcGIS geocoding features
+easier to access. The API endpoints used by **arcgeocoder** are
+`findAddressCandidates` and `reverseGeocode`, which can be accessed without an
+API key.
 
 ## Recommended packages
 
@@ -155,7 +156,7 @@ eiffel_tower <- arc_geo_multi(
 eiffel_tower |>
   select(lon, lat, LongLabel)
 
-# Use `lon` and `lat` to boost the search with `category = "Food"`.
+# Use `lon` and `lat` as a reference location for `category = "Food"`.
 food_eiffel <- arc_geo_categories(
   "Food",
   x = eiffel_tower$lon,

--- a/vignettes/articles/leaflet.qmd
+++ b/vignettes/articles/leaflet.qmd
@@ -1,6 +1,6 @@
 ---
 title: arcgeocoder and leaflet maps
-description: Combine arcgeocoder and leaflet maps.
+description: Combine arcgeocoder with leaflet maps.
 knitr:
   opts_chunk:
     collapse: true
@@ -16,10 +16,10 @@ knitr:
 ## Example
 
 The following example shows how to create an interactive
-[leaflet map](https://rstudio.github.io/leaflet/) using data retrieved with
+[**leaflet** map](https://rstudio.github.io/leaflet/) using data retrieved with
 **arcgeocoder**.
 
-This widget can be browsed and filtered with **crosstalk** and **reactable**:
+This widget can be browsed and filtered with **crosstalk** and **reactable**.
 
 ```{r}
 #| label: example

--- a/vignettes/articles/static.qmd
+++ b/vignettes/articles/static.qmd
@@ -16,7 +16,7 @@ knitr:
 ## Example 1: sf objects
 
 The following example shows how to create a static map using data retrieved
-with **arcgeocoder** and converted to an **sf** object:
+with **arcgeocoder** and converted to an **sf** object.
 
 ```{r}
 #| label: sf
@@ -40,7 +40,7 @@ mc <- arc_geo_multi(
   custom_query = list(outFields = c("LongLabel", "Type", "StAddr"))
 )
 
-# Convert to an **sf** object.
+# Convert to an sf object.
 mc_sf <- st_as_sf(
   mc,
   coords = c("lon", "lat"),
@@ -87,7 +87,7 @@ ggplot(bcn) +
 
 We can add static map tiles with the **maptiles** package and use the
 **tidyterra** package for plotting. The tiles are represented here as
-**terra** objects:
+**terra** objects.
 
 ```{r}
 #| label: terra

--- a/vignettes/feature-types.qmd
+++ b/vignettes/feature-types.qmd
@@ -18,7 +18,7 @@ vignette: >
 ## Reverse geocoding details
 
 The purpose of reverse geocoding is to answer the question: what is near this
-location? The `reverseGeocode` operation provided by the **ArcGIS REST API**
+location? The `reverseGeocode` operation provided by the ArcGIS REST API
 returns the most relevant feature near an input location based on a prioritized
 hierarchy of feature types.
 
@@ -32,7 +32,7 @@ the *Search tolerance* column.
 | Feature type | Search tolerance | Comments |
 |----|----|----|
 | `StreetInt` | 10 meters | Intersections are only returned when `featuretypes = "StreetInt"` is included in the request. |
-| `StreetAddress` (near), `DistanceMarker`, or `StreetName` | 3 meters | Candidates of type `StreetName` are only returned if `featureTypes = "streetName"` is included in the request. |
+| `StreetAddress` (near), `DistanceMarker`, or `StreetName` | 3 meters | Candidates of type `StreetName` are only returned if `featuretypes = "StreetName"` is included in the request. |
 | `POI` centroid | 25 meters | A business or landmark that can be represented by a point. |
 | `Subaddress` | 10 meters | `Subaddress` candidates, which can be features such as apartments or floors in a building, may not be returned under certain conditions. |
 | `PointAddress` | 50 meters | A `PointAddress` match is not returned if it is on the opposite side of the street as the input location, even if it is within 50 meters of the location. |
@@ -213,7 +213,8 @@ The following example presents a case where only certain `featuretypes` are
 near the requested location. In this case, when reverse geocoding the North
 Pole, the API returns a `Locality`, but no `StreetAddress` is found.
 
-When no results are available, `arc_reverse_geo()` returns an empty **tibble**.
+When no results are available, `arc_reverse_geo()` returns a **tibble** with
+the requested address column set to `NA`.
 
 
 ``` r

--- a/vignettes/feature-types.qmd.orig
+++ b/vignettes/feature-types.qmd.orig
@@ -31,7 +31,7 @@ knitr::opts_chunk$set(
 ## Reverse geocoding details
 
 The purpose of reverse geocoding is to answer the question: what is near this
-location? The `reverseGeocode` operation provided by the **ArcGIS REST API**
+location? The `reverseGeocode` operation provided by the ArcGIS REST API
 returns the most relevant feature near an input location based on a prioritized
 hierarchy of feature types.
 
@@ -45,7 +45,7 @@ the *Search tolerance* column.
 | Feature type | Search tolerance | Comments |
 |----|----|----|
 | `StreetInt` | 10 meters | Intersections are only returned when `featuretypes = "StreetInt"` is included in the request. |
-| `StreetAddress` (near), `DistanceMarker`, or `StreetName` | 3 meters | Candidates of type `StreetName` are only returned if `featureTypes = "streetName"` is included in the request. |
+| `StreetAddress` (near), `DistanceMarker`, or `StreetName` | 3 meters | Candidates of type `StreetName` are only returned if `featuretypes = "StreetName"` is included in the request. |
 | `POI` centroid | 25 meters | A business or landmark that can be represented by a point. |
 | `Subaddress` | 10 meters | `Subaddress` candidates, which can be features such as apartments or floors in a building, may not be returned under certain conditions. |
 | `PointAddress` | 50 meters | A `PointAddress` match is not returned if it is on the opposite side of the street as the input location, even if it is within 50 meters of the location. |
@@ -194,7 +194,8 @@ The following example presents a case where only certain `featuretypes` are
 near the requested location. In this case, when reverse geocoding the North
 Pole, the API returns a `Locality`, but no `StreetAddress` is found.
 
-When no results are available, `arc_reverse_geo()` returns an empty **tibble**.
+When no results are available, `arc_reverse_geo()` returns a **tibble** with
+the requested address column set to `NA`.
 
 ```{r}
 #| label: noloc


### PR DESCRIPTION
## Summary

- Refactor internal geocoding helpers to centralize query construction, progress handling, validation and API call utilities.
- Align roxygen2, README, vignettes, package metadata and pkgdown terminology for internal consistency.
- Add NEWS entries that explicitly document AI assistance for the refactor and documentation review.
- Add focused utility coverage for multi-field query row handling and keep updated snapshots.

## Validation

- `devtools::load_all(); lintr::lint_package()`
- `pkgdown::check_pkgdown()`
- `git diff --check`

Full package tests were intentionally left for local parallel execution.
